### PR TITLE
PR1: BCH Pubkey Indexer — Start9 s9pk build fixes

### DIFF
--- a/.github/workflows/build-indexer-s9pk.yml
+++ b/.github/workflows/build-indexer-s9pk.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Prepare StartOS SDK
-        uses: Start9Labs/sdk@v1
+        uses: Start9Labs/sdk@v2
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-indexer-s9pk.yml
+++ b/.github/workflows/build-indexer-s9pk.yml
@@ -1,0 +1,41 @@
+name: Build BCH Pubkey Indexer s9pk
+
+on:
+  push:
+    tags:
+      - 'indexer-v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Prepare StartOS SDK
+        uses: Start9Labs/sdk@v1
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build s9pk
+        working-directory: indexer/start9
+        run: |
+          start-cli init-key
+          npm ci
+          make
+        shell: bash
+
+      - name: Generate sha256 checksum
+        working-directory: indexer/start9
+        run: |
+          sha256sum bch-pubkey-indexer.s9pk > bch-pubkey-indexer.s9pk.sha256
+          echo "SHA256: $(cat bch-pubkey-indexer.s9pk.sha256)"
+
+      - name: Upload s9pk to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: |
+            indexer/start9/bch-pubkey-indexer.s9pk
+            indexer/start9/bch-pubkey-indexer.s9pk.sha256

--- a/README.md
+++ b/README.md
@@ -314,10 +314,10 @@ Pre-built self-contained binaries. No installation, no Node.js required.
 
 | Platform | File | Size |
 |----------|------|------|
-| Linux x64 | [`dist/pubkey-indexer-linux`](dist/pubkey-indexer-linux) | ~45 MB |
-| macOS Intel | [`dist/pubkey-indexer-mac`](dist/pubkey-indexer-mac) | ~50 MB |
-| macOS Apple Silicon | [`dist/pubkey-indexer-mac-arm64`](dist/pubkey-indexer-mac-arm64) | ~45 MB |
-| Windows x64 | [`dist/pubkey-indexer-win.exe`](dist/pubkey-indexer-win.exe) | ~37 MB |
+| Linux x64 | [`BCH-Pubkey-Indexer-linux`](dist/pubkey-indexer-linux) | ~45 MB |
+| macOS Intel | [`BCH-Pubkey-Indexer-mac`](dist/pubkey-indexer-mac) | ~50 MB |
+| macOS Apple Silicon | [`BCH-Pubkey-Indexer-mac-arm64`](dist/pubkey-indexer-mac-arm64) | ~45 MB |
+| Windows x64 | [`BCH-Pubkey-Indexer-win.exe`](dist/pubkey-indexer-win.exe) | ~37 MB |
 
 **Linux / macOS:**
 ```bash
@@ -343,9 +343,10 @@ Self-host on [Start9](https://start9.com) (OS 0.4.0+) as a background service wi
 **Build the `.s9pk` package:**
 ```bash
 cd indexer/start9
+npm ci
 make
 # → bch-pubkey-indexer.s9pk
-start-sdk verify bch-pubkey-indexer.s9pk
+start-cli s9pk inspect bch-pubkey-indexer.s9pk
 ```
 
 **Install:** Sideload `bch-pubkey-indexer.s9pk` via Start9 UI → Services → Sideload.
@@ -353,17 +354,7 @@ start-sdk verify bch-pubkey-indexer.s9pk
 **What you get:**
 - HTTP API on port 3847 (LAN + SSL)
 - Tor `.onion` address auto-generated — share with mobile wallet for remote access
-- Auto-discovers BCHN at `http://bchn:8332` if installed on same server
-- Falls back to public Fulcrum servers if no node
-
-**Config options (set via Start9 UI):**
-
-| Setting | Options | Default |
-|---------|---------|---------|
-| Source | Fulcrum / Local Node (BCHN) | Fulcrum |
-| Fulcrum URL | wss://... | auto-rotate public servers |
-| BCHN RPC URL | http://... | http://bchn:8332 |
-| Max block range | 10–500 | 100 blocks |
+- Connects to public Fulcrum servers by default; point to a local BCHN node with `--rpc-url`
 
 ---
 

--- a/indexer/start9/Dockerfile
+++ b/indexer/start9/Dockerfile
@@ -3,7 +3,7 @@ FROM node:18-slim
 WORKDIR /app
 
 # Copy the indexer
-COPY ../pubkey-indexer.js /app/pubkey-indexer.js
+COPY pubkey-indexer.js /app/pubkey-indexer.js
 
 # Install ws dependency
 RUN npm install ws && npm cache clean --force

--- a/indexer/start9/package.json
+++ b/indexer/start9/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "^0.4.0-beta.62"
+    "@start9labs/start-sdk": "^0.4.0-beta.63"
   },
   "devDependencies": {
     "@types/node": "^22.19.0",

--- a/indexer/start9/startos/init/seedFiles.ts
+++ b/indexer/start9/startos/init/seedFiles.ts
@@ -1,6 +1,6 @@
 import { sdk } from '../sdk'
 
-export const seedFiles = sdk.setupSeedFiles(async ({ effects }) => {
+export const seedFiles = sdk.setupOnInit(async (effects) => {
   // Create cache directories on first init
   await effects.createDir({
     volumeId: 'main',

--- a/indexer/start9/startos/manifest.ts
+++ b/indexer/start9/startos/manifest.ts
@@ -19,7 +19,7 @@ export const manifest = setupManifest({
   volumes: ['main'],
   images: {
     main: {
-      source: { dockerTag: 'start9labs/bch-pubkey-indexer:latest' },
+      source: { dockerBuild: { workdir: '..', dockerfile: 'start9/Dockerfile' } },
     },
   },
   alerts: {


### PR DESCRIPTION
## Summary

Fixes all blockers preventing the Start9 `.s9pk` package from building, adds CI automation, and cleans up docs.

### Build fixes (`indexer/start9/`)

- **`seedFiles.ts`** — `sdk.setupSeedFiles()` does not exist in any SDK version; replaced with `sdk.setupOnInit()` which is the correct API
- **`manifest.ts`** — `dockerTag: 'start9labs/bch-pubkey-indexer:latest'` points to a non-existent Docker Hub image; replaced with `dockerBuild` using the local Dockerfile
- **`Dockerfile`** — `COPY ../pubkey-indexer.js` fails (Docker rejects parent-dir traversal); set `workdir: '..'` in manifest so build context is `indexer/`, then `COPY pubkey-indexer.js` works directly
- **`package.json`** — bump `@start9labs/start-sdk` from `^0.4.0-beta.62` to `^0.4.0-beta.63`

### CI (`/.github/workflows/build-indexer-s9pk.yml`)

Adds a GitHub Actions workflow that triggers on `indexer-v*` tags, builds the `.s9pk` using `Start9Labs/sdk@v1`, and uploads `bch-pubkey-indexer.s9pk` + sha256 to the release automatically.

### Docs (`README.md`)

- Rename download links to `BCH-Pubkey-Indexer-*` to match release assets
- Fix build command: `start-sdk verify` → `start-cli s9pk inspect`
- Add `npm ci` step before `make`
- Remove unimplemented Config options table (no `inputSpec` in current start9 code)
- Remove false "Auto-discovers BCHN" claim

## Test plan

- [ ] Merge to main
- [ ] Delete and recreate tag `indexer-v1.0.0` on main (or push a new `indexer-v1.0.1` tag) to trigger the CI workflow
- [ ] Verify `bch-pubkey-indexer.s9pk` appears in release assets
- [ ] Sideload `.s9pk` on a Start9 server running OS 0.4.0+